### PR TITLE
Add logic to support cut master sidequest

### DIFF
--- a/data/maps/TranquilRoute/scripts.inc
+++ b/data/maps/TranquilRoute/scripts.inc
@@ -1,264 +1,380 @@
 TranquilRoute_MapScripts::
+# 8 "data/maps/TranquilRoute/scripts.pory"
+	map_script MAP_SCRIPT_ON_LOAD, TranquilRoute_CheckCutGrass
 	.byte 0
 
 
+TranquilRoute_CheckCutGrass::
+# 13 "data/maps/TranquilRoute/scripts.pory"
+	call_if_set FLAG_COMPLETED_CUT_QUEST, TranquilRoute_EventScript_CutGrass
+	end
+
+
+TranquilRoute_EventScript_CutGrass::
+# 23 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 31, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 25 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 30, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 27 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 29, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 28 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 29, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 30 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 31 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 32 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 34 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 35 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 36 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 38 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 26, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 39 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 26, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 41 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 25, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 43 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 24, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 45 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 23, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 46 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 23, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 48 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 41, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 49 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 42, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 50 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 51 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 53 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 40, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 54 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 41, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 55 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 42, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 56 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 43, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 57 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 45, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 58 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 59 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 60 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 62 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 41, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 63 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 42, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 64 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 43, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 65 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 44, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 66 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 45, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 67 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 68 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 69 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 71 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 40, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 72 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 42, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 73 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 43, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 74 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 44, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 75 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 45, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 76 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 77 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 78 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 79 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 49, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 81 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 41, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 82 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 43, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 83 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 44, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 84 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 45, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 85 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 46, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 86 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 47, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+# 87 "data/maps/TranquilRoute/scripts.pory"
+	setmetatile 48, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE
+	return
+
+
 TranquilRoute_EventScript_Chikao::
-# 10 "data/maps/TranquilRoute/scripts.pory"
+# 92 "data/maps/TranquilRoute/scripts.pory"
 	trainerbattle_single TRAINER_CHIKAO, TranquilRoute_EventScript_Chikao_Text_0, TranquilRoute_EventScript_Chikao_Text_1
-# 15 "data/maps/TranquilRoute/scripts.pory"
+# 97 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Chikao_Text_2, MSGBOX_AUTOCLOSE
 	end
 
 
 TranquilRoute_EventScript_Takeshi::
-# 20 "data/maps/TranquilRoute/scripts.pory"
+# 102 "data/maps/TranquilRoute/scripts.pory"
 	trainerbattle_single TRAINER_TAKESHI, TranquilRoute_EventScript_Takeshi_Text_0, TranquilRoute_EventScript_Takeshi_Text_1
-# 25 "data/maps/TranquilRoute/scripts.pory"
+# 107 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Takeshi_Text_2, MSGBOX_AUTOCLOSE
 	end
 
 
 TranquilRoute_EventScript_Hana::
-# 30 "data/maps/TranquilRoute/scripts.pory"
+# 112 "data/maps/TranquilRoute/scripts.pory"
 	trainerbattle_single TRAINER_HIINA, TranquilRoute_EventScript_Hana_Text_0, TranquilRoute_EventScript_Hana_Text_1
-# 35 "data/maps/TranquilRoute/scripts.pory"
+# 117 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Hana_Text_2, MSGBOX_AUTOCLOSE
 	end
 
 
 TranquilRoute_EventScript_Kenji::
-# 40 "data/maps/TranquilRoute/scripts.pory"
+# 122 "data/maps/TranquilRoute/scripts.pory"
 	trainerbattle_single TRAINER_KENJI, TranquilRoute_EventScript_Kenji_Text_0, TranquilRoute_EventScript_Kenji_Text_1
-# 45 "data/maps/TranquilRoute/scripts.pory"
+# 127 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Kenji_Text_2, MSGBOX_AUTOCLOSE
 	end
 
 
 TranquilRoute_EventScript_MysteriousSamurai::
-# 54 "data/maps/TranquilRoute/scripts.pory"
+# 136 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 56 "data/maps/TranquilRoute/scripts.pory"
+# 138 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_MysteriousSamurai_Text_0
-# 63 "data/maps/TranquilRoute/scripts.pory"
+# 145 "data/maps/TranquilRoute/scripts.pory"
 	closemessage
-# 65 "data/maps/TranquilRoute/scripts.pory"
+# 147 "data/maps/TranquilRoute/scripts.pory"
 	applymovement 9, TranquilRoute_Movement_MysteriousSamuraiWalksAway
-# 66 "data/maps/TranquilRoute/scripts.pory"
+# 148 "data/maps/TranquilRoute/scripts.pory"
 	removeobject 9
-# 68 "data/maps/TranquilRoute/scripts.pory"
+# 150 "data/maps/TranquilRoute/scripts.pory"
 	setflag FLAG_MYSTERIOUS_SAMURAI_TRANQUIL_ROUTE
-# 69 "data/maps/TranquilRoute/scripts.pory"
+# 151 "data/maps/TranquilRoute/scripts.pory"
 	release
 	end
 
 
-# 73 "data/maps/TranquilRoute/scripts.pory"
+# 155 "data/maps/TranquilRoute/scripts.pory"
 TranquilRoute_Movement_MysteriousSamuraiWalksAway:
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
-# 74 "data/maps/TranquilRoute/scripts.pory"
+# 156 "data/maps/TranquilRoute/scripts.pory"
 	walk_right
 	step_end
 
 TranquilRoute_EventScript_Girl::
-# 78 "data/maps/TranquilRoute/scripts.pory"
+# 160 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 79 "data/maps/TranquilRoute/scripts.pory"
+# 161 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Girl_Text_0, MSGBOX_AUTOCLOSE
-# 80 "data/maps/TranquilRoute/scripts.pory"
+# 162 "data/maps/TranquilRoute/scripts.pory"
 	release
 	end
 
 
 TranquilRoute_EventScript_Shellos::
-# 85 "data/maps/TranquilRoute/scripts.pory"
+# 167 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 86 "data/maps/TranquilRoute/scripts.pory"
+# 168 "data/maps/TranquilRoute/scripts.pory"
 	faceplayer
-# 87 "data/maps/TranquilRoute/scripts.pory"
+# 169 "data/maps/TranquilRoute/scripts.pory"
 	playmoncry SPECIES_SHELLOS, CRY_MODE_NORMAL
-# 88 "data/maps/TranquilRoute/scripts.pory"
+# 170 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Shellos_Text_0
-# 91 "data/maps/TranquilRoute/scripts.pory"
+# 173 "data/maps/TranquilRoute/scripts.pory"
 	waitmoncry
-# 92 "data/maps/TranquilRoute/scripts.pory"
+# 174 "data/maps/TranquilRoute/scripts.pory"
 	closemessage
-# 93 "data/maps/TranquilRoute/scripts.pory"
+# 175 "data/maps/TranquilRoute/scripts.pory"
 	release
 	end
 
 
 TranquilRoute_EventScript_BerryWoman::
-# 98 "data/maps/TranquilRoute/scripts.pory"
+# 180 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 99 "data/maps/TranquilRoute/scripts.pory"
+# 181 "data/maps/TranquilRoute/scripts.pory"
 	faceplayer
-# 101 "data/maps/TranquilRoute/scripts.pory"
+# 183 "data/maps/TranquilRoute/scripts.pory"
 	goto_if_set FLAG_RECEIVED_WAILMER_PAIL, TranquilRoute_EventScript_BerryWoman_2
-# 105 "data/maps/TranquilRoute/scripts.pory"
+# 187 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_BerryWoman_Text_1
-# 106 "data/maps/TranquilRoute/scripts.pory"
+# 188 "data/maps/TranquilRoute/scripts.pory"
 	closemessage
-# 107 "data/maps/TranquilRoute/scripts.pory"
+# 189 "data/maps/TranquilRoute/scripts.pory"
 	applymovement 5, Common_Movement_FaceRight
-# 108 "data/maps/TranquilRoute/scripts.pory"
+# 190 "data/maps/TranquilRoute/scripts.pory"
 	waitmovement 0
-# 109 "data/maps/TranquilRoute/scripts.pory"
+# 191 "data/maps/TranquilRoute/scripts.pory"
 	delay 48
-# 110 "data/maps/TranquilRoute/scripts.pory"
+# 192 "data/maps/TranquilRoute/scripts.pory"
 	applymovement 5, Common_Movement_FacePlayer
-# 111 "data/maps/TranquilRoute/scripts.pory"
+# 193 "data/maps/TranquilRoute/scripts.pory"
 	waitmovement 0
-# 112 "data/maps/TranquilRoute/scripts.pory"
+# 194 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_BerryWoman_Text_2
-# 119 "data/maps/TranquilRoute/scripts.pory"
+# 201 "data/maps/TranquilRoute/scripts.pory"
 	closemessage
-# 120 "data/maps/TranquilRoute/scripts.pory"
+# 202 "data/maps/TranquilRoute/scripts.pory"
 	giveitem ITEM_ORAN_BERRY, 3
-# 121 "data/maps/TranquilRoute/scripts.pory"
+# 203 "data/maps/TranquilRoute/scripts.pory"
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
-# 123 "data/maps/TranquilRoute/scripts.pory"
+# 205 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_BerryWoman_Text_3
-# 128 "data/maps/TranquilRoute/scripts.pory"
+# 210 "data/maps/TranquilRoute/scripts.pory"
 	closemessage
-# 129 "data/maps/TranquilRoute/scripts.pory"
+# 211 "data/maps/TranquilRoute/scripts.pory"
 	giveitem ITEM_WAILMER_PAIL
-# 130 "data/maps/TranquilRoute/scripts.pory"
+# 212 "data/maps/TranquilRoute/scripts.pory"
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
-# 132 "data/maps/TranquilRoute/scripts.pory"
+# 214 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_BerryWoman_Text_4
-# 138 "data/maps/TranquilRoute/scripts.pory"
+# 220 "data/maps/TranquilRoute/scripts.pory"
 	setflag FLAG_RECEIVED_WAILMER_PAIL
 TranquilRoute_EventScript_BerryWoman_1:
-# 140 "data/maps/TranquilRoute/scripts.pory"
+# 222 "data/maps/TranquilRoute/scripts.pory"
 	release
 	end
 
 TranquilRoute_EventScript_BerryWoman_2:
-# 102 "data/maps/TranquilRoute/scripts.pory"
+# 184 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_BerryWoman_Text_0
 	goto TranquilRoute_EventScript_BerryWoman_1
 
 
 TranquilRoute_EventScript_Mareep::
-# 145 "data/maps/TranquilRoute/scripts.pory"
+# 227 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 146 "data/maps/TranquilRoute/scripts.pory"
+# 228 "data/maps/TranquilRoute/scripts.pory"
 	playmoncry SPECIES_MAREEP, CRY_MODE_NORMAL
-# 147 "data/maps/TranquilRoute/scripts.pory"
+# 229 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Mareep_Text_0, MSGBOX_AUTOCLOSE
-# 148 "data/maps/TranquilRoute/scripts.pory"
+# 230 "data/maps/TranquilRoute/scripts.pory"
 	waitmoncry
-# 149 "data/maps/TranquilRoute/scripts.pory"
+# 231 "data/maps/TranquilRoute/scripts.pory"
 	release
 	return
 
 
 TranquilRoute_EventScript_Mareep2::
-# 153 "data/maps/TranquilRoute/scripts.pory"
+# 235 "data/maps/TranquilRoute/scripts.pory"
 	lock
-# 154 "data/maps/TranquilRoute/scripts.pory"
+# 236 "data/maps/TranquilRoute/scripts.pory"
 	playmoncry SPECIES_MAREEP, CRY_MODE_WEAK
-# 155 "data/maps/TranquilRoute/scripts.pory"
+# 237 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_EventScript_Mareep2_Text_0, MSGBOX_AUTOCLOSE
-# 156 "data/maps/TranquilRoute/scripts.pory"
+# 238 "data/maps/TranquilRoute/scripts.pory"
 	waitmoncry
-# 157 "data/maps/TranquilRoute/scripts.pory"
+# 239 "data/maps/TranquilRoute/scripts.pory"
 	release
 	return
 
 
 TranquilRoute_TrainerTips1::
-# 161 "data/maps/TranquilRoute/scripts.pory"
+# 243 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_TrainerTips1_Text_0, MSGBOX_SIGN
 	return
 
 
 TranquilRoute_TrainerTips2::
-# 170 "data/maps/TranquilRoute/scripts.pory"
+# 252 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_TrainerTips2_Text_0, MSGBOX_SIGN
 	return
 
 
 TranquilRoute_DirectionSign::
-# 177 "data/maps/TranquilRoute/scripts.pory"
+# 259 "data/maps/TranquilRoute/scripts.pory"
 	goto_if_set FLAG_SAKU_KURA_REUNITED, TranquilRoute_DirectionSign_1
-# 184 "data/maps/TranquilRoute/scripts.pory"
+# 266 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_DirectionSign_Text_1, MSGBOX_SIGN
 	return
 
 TranquilRoute_DirectionSign_1:
-# 178 "data/maps/TranquilRoute/scripts.pory"
+# 260 "data/maps/TranquilRoute/scripts.pory"
 	msgbox TranquilRoute_DirectionSign_Text_0, MSGBOX_SIGN
 	return
 
 
 TranquilRoute_EventScript_Chikao_Text_0:
-# 12 "data/maps/TranquilRoute/scripts.pory"
+# 94 "data/maps/TranquilRoute/scripts.pory"
 	.string "I've been studying Pokémon at school! I\n"
 	.string "can't lose!$"
 
 TranquilRoute_EventScript_Chikao_Text_1:
-# 13 "data/maps/TranquilRoute/scripts.pory"
+# 95 "data/maps/TranquilRoute/scripts.pory"
 	.string "I should have listened in class…$"
 
 TranquilRoute_EventScript_Chikao_Text_2:
-# 15 "data/maps/TranquilRoute/scripts.pory"
+# 97 "data/maps/TranquilRoute/scripts.pory"
 	.string "Some Pokémon have more attack, and some have more special attack!\p What's the difference? Uhh… It's too complicated to explain.$"
 
 TranquilRoute_EventScript_Takeshi_Text_0:
-# 22 "data/maps/TranquilRoute/scripts.pory"
+# 104 "data/maps/TranquilRoute/scripts.pory"
 	.string "Stay right there! I'll defeat you with\n"
 	.string "my ninja skills!$"
 
 TranquilRoute_EventScript_Takeshi_Text_1:
-# 23 "data/maps/TranquilRoute/scripts.pory"
+# 105 "data/maps/TranquilRoute/scripts.pory"
 	.string "I had the sun in my eyes!$"
 
 TranquilRoute_EventScript_Takeshi_Text_2:
-# 25 "data/maps/TranquilRoute/scripts.pory"
+# 107 "data/maps/TranquilRoute/scripts.pory"
 	.string "I must hone my ninja skills!$"
 
 TranquilRoute_EventScript_Hana_Text_0:
-# 32 "data/maps/TranquilRoute/scripts.pory"
+# 114 "data/maps/TranquilRoute/scripts.pory"
 	.string "Ugh, how can Kenji paint a portrait of\n"
 	.string "me if people keep walking between us?$"
 
 TranquilRoute_EventScript_Hana_Text_1:
-# 33 "data/maps/TranquilRoute/scripts.pory"
+# 115 "data/maps/TranquilRoute/scripts.pory"
 	.string "Great, now my hair is all messed up.$"
 
 TranquilRoute_EventScript_Hana_Text_2:
-# 35 "data/maps/TranquilRoute/scripts.pory"
+# 117 "data/maps/TranquilRoute/scripts.pory"
 	.string "Kenji really is an amazing artist. I feel\n"
 	.string "very lucky.$"
 
 TranquilRoute_EventScript_Kenji_Text_0:
-# 42 "data/maps/TranquilRoute/scripts.pory"
+# 124 "data/maps/TranquilRoute/scripts.pory"
 	.string "You're interrupting my creative flow!!$"
 
 TranquilRoute_EventScript_Kenji_Text_1:
-# 43 "data/maps/TranquilRoute/scripts.pory"
+# 125 "data/maps/TranquilRoute/scripts.pory"
 	.string "Such beauty! What an artistic fight\n"
 	.string "this was!$"
 
 TranquilRoute_EventScript_Kenji_Text_2:
-# 46 "data/maps/TranquilRoute/scripts.pory"
+# 128 "data/maps/TranquilRoute/scripts.pory"
 	.string "Hiina is the best subject I could dream\n"
 	.string "of.\p"
 	.string "…Hey, uh, please don't tell her I said\n"
 	.string "that.$"
 
 TranquilRoute_EventScript_MysteriousSamurai_Text_0:
-# 57 "data/maps/TranquilRoute/scripts.pory"
+# 139 "data/maps/TranquilRoute/scripts.pory"
 	.string "So you are one of those new Pokémon\n"
 	.string "wielders, right?\p"
 	.string "You say Pokémon have been restless,\n"
@@ -269,24 +385,24 @@ TranquilRoute_EventScript_MysteriousSamurai_Text_0:
 	.string "Until then, farewell.$"
 
 TranquilRoute_EventScript_Girl_Text_0:
-# 79 "data/maps/TranquilRoute/scripts.pory"
+# 161 "data/maps/TranquilRoute/scripts.pory"
 	.string "What? Oh, I don't fight.\p"
 	.string "My Pokémon and I are just strolling.$"
 
 TranquilRoute_EventScript_Shellos_Text_0:
-# 89 "data/maps/TranquilRoute/scripts.pory"
+# 171 "data/maps/TranquilRoute/scripts.pory"
 	.string "Clelel!$"
 
 TranquilRoute_EventScript_BerryWoman_Text_0:
-# 102 "data/maps/TranquilRoute/scripts.pory"
+# 184 "data/maps/TranquilRoute/scripts.pory"
 	.string "Enjoy gardening!$"
 
 TranquilRoute_EventScript_BerryWoman_Text_1:
-# 105 "data/maps/TranquilRoute/scripts.pory"
+# 187 "data/maps/TranquilRoute/scripts.pory"
 	.string "Hi, young one! See this?$"
 
 TranquilRoute_EventScript_BerryWoman_Text_2:
-# 113 "data/maps/TranquilRoute/scripts.pory"
+# 195 "data/maps/TranquilRoute/scripts.pory"
 	.string "You can plant berries in the ground in\n"
 	.string "fertile spots like this.\p"
 	.string "The seeds will eventually grow into a\n"
@@ -300,28 +416,28 @@ TranquilRoute_EventScript_BerryWoman_Text_2:
 	.string "Here, try planting a few!$"
 
 TranquilRoute_EventScript_BerryWoman_Text_3:
-# 124 "data/maps/TranquilRoute/scripts.pory"
+# 206 "data/maps/TranquilRoute/scripts.pory"
 	.string "Oh, right, I was almost forgetting!\p"
 	.string "You must remember to water them\n"
 	.string "regularly, or they won't grow!\p"
 	.string "I like you. Take this!$"
 
 TranquilRoute_EventScript_BerryWoman_Text_4:
-# 133 "data/maps/TranquilRoute/scripts.pory"
+# 215 "data/maps/TranquilRoute/scripts.pory"
 	.string "Isn't it cute? It's friend-shaped!\p"
 	.string "Don't worry about it, I have a spare one.\p"
 	.string "Have fun gardening!$"
 
 TranquilRoute_EventScript_Mareep_Text_0:
-# 147 "data/maps/TranquilRoute/scripts.pory"
+# 229 "data/maps/TranquilRoute/scripts.pory"
 	.string "Beeeeeh…$"
 
 TranquilRoute_EventScript_Mareep2_Text_0:
-# 155 "data/maps/TranquilRoute/scripts.pory"
+# 237 "data/maps/TranquilRoute/scripts.pory"
 	.string "Baaaaah…$"
 
 TranquilRoute_TrainerTips1_Text_0:
-# 162 "data/maps/TranquilRoute/scripts.pory"
+# 244 "data/maps/TranquilRoute/scripts.pory"
 	.string "Did you know?\p"
 	.string "Some Pokémon only come out in the\n"
 	.string "morning, in the evening, or at night.\p"
@@ -330,19 +446,19 @@ TranquilRoute_TrainerTips1_Text_0:
 	.string "Pokémon!$"
 
 TranquilRoute_TrainerTips2_Text_0:
-# 171 "data/maps/TranquilRoute/scripts.pory"
+# 253 "data/maps/TranquilRoute/scripts.pory"
 	.string "Did you know?\p"
 	.string "Several items can be assigned to the\n"
 	.string "SELECT button from your bag.$"
 
 TranquilRoute_DirectionSign_Text_0:
-# 179 "data/maps/TranquilRoute/scripts.pory"
+# 261 "data/maps/TranquilRoute/scripts.pory"
 	.string "{LEFT_ARROW} Whiteslate route\n"
 	.string "{UP_ARROW} Sakura Village\p"
 	.string "It looks like the sign has been written\n"
 	.string "over recently…$"
 
 TranquilRoute_DirectionSign_Text_1:
-# 185 "data/maps/TranquilRoute/scripts.pory"
+# 267 "data/maps/TranquilRoute/scripts.pory"
 	.string "{LEFT_ARROW} Whiteslate route\n"
 	.string "{UP_ARROW} Saku and Kura Villages$"

--- a/data/maps/TranquilRoute/scripts.pory
+++ b/data/maps/TranquilRoute/scripts.pory
@@ -3,7 +3,89 @@ const LOCALID_MYSTERIOUS_SAMURAI = 9
 
 
 mapscripts TranquilRoute_MapScripts {
+	// uhh idk if this is the right script to use (on load vs on transition or whatever)
+	// but it works for walking in and out of the house!
+	MAP_SCRIPT_ON_LOAD: TranquilRoute_CheckCutGrass
+	
+}
 
+script TranquilRoute_CheckCutGrass{
+	call_if_set(FLAG_COMPLETED_CUT_QUEST, TranquilRoute_EventScript_CutGrass)
+	end
+}
+
+// i just set them all to METATILE_PorytilesPrimaryTutorial_Grass2
+// probably do METATILE_PorytilesPrimaryTutorial_Grass or METATILE_PorytilesPrimaryTutorial_Grass3
+// or maybe even some flowers as your artist's eye desires
+script TranquilRoute_EventScript_CutGrass {
+	// there is probably a smarter way to do this but here we are
+	// set all the tiles that were cut to just be normal grass
+	setmetatile(47, 31, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(48, 30, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(46, 29, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 29, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(46, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 28, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(46, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 27, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(47, 26, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 26, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(47, 25, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(47, 24, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(46, 23, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 23, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	
+	setmetatile(41, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(42, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(46, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 22, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+
+	setmetatile(40, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(41, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(42, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(43, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(45, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(46, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 21, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+
+	setmetatile(41, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(42, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(43, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(44, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(45, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(46, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 20, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+
+	setmetatile(40, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(42, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(43, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(44, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(45, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(46, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(49, 19, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+
+	setmetatile(41, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(43, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(44, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(45, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(46, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(47, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	setmetatile(48, 18, METATILE_PorytilesPrimaryTutorial_Grass2, FALSE)
+	return
 }
 
 script TranquilRoute_EventScript_Chikao {

--- a/data/maps/TranquilRoute_CutHouse/scripts.inc
+++ b/data/maps/TranquilRoute_CutHouse/scripts.inc
@@ -8,19 +8,22 @@ TranquilRoute_CutHouse_EventScript_CutMaster::
 # 7 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	faceplayer
 # 9 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	goto_if_set FLAG_RECEIVED_HM_CUT, TranquilRoute_CutHouse_EventScript_CutMaster_2
-# 16 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_1
-# 23 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	closemessage
-# 25 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	giveitem ITEM_HM_CUT
-# 26 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	setflag FLAG_RECEIVED_HM_CUT
-# 27 "data/maps/TranquilRoute_CutHouse/scripts.pory"
-	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_2
+	goto_if_set FLAG_COMPLETED_CUT_QUEST, TranquilRoute_CutHouse_EventScript_CutMaster_2
 TranquilRoute_CutHouse_EventScript_CutMaster_1:
-# 35 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+# 15 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	goto_if_set FLAG_RECEIVED_HM_CUT, TranquilRoute_CutHouse_EventScript_CutMaster_5
+# 22 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_2
+# 29 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	closemessage
+# 31 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	giveitem ITEM_HM_CUT
+# 32 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	setflag FLAG_RECEIVED_HM_CUT
+# 33 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_3
+TranquilRoute_CutHouse_EventScript_CutMaster_4:
+# 41 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	release
 	return
 
@@ -29,16 +32,26 @@ TranquilRoute_CutHouse_EventScript_CutMaster_2:
 	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_0
 	goto TranquilRoute_CutHouse_EventScript_CutMaster_1
 
+TranquilRoute_CutHouse_EventScript_CutMaster_5:
+# 16 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_CutMaster_Text_1
+	goto TranquilRoute_CutHouse_EventScript_CutMaster_4
+
 
 TranquilRoute_CutHouse_EventScript_CutMaster_Text_0:
 # 11 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "you actually cut all that grass\n"
+	.string "absolute psycho$"
+
+TranquilRoute_CutHouse_EventScript_CutMaster_Text_1:
+# 17 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	.string "Are you finding the Cut technique\n"
 	.string "useful?\p"
 	.string "No, I still haven't trimmed my garden. I\n"
 	.string "really should get to it…$"
 
-TranquilRoute_CutHouse_EventScript_CutMaster_Text_1:
-# 17 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+TranquilRoute_CutHouse_EventScript_CutMaster_Text_2:
+# 23 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	.string "Hello, there. I don't get many visitors,\n"
 	.string "so sit down, have some tea!\p"
 	.string "What? The weeds are growing all over\n"
@@ -50,8 +63,8 @@ TranquilRoute_CutHouse_EventScript_CutMaster_Text_1:
 	.string "Here, your Pokémon can trim them using\n"
 	.string "this.$"
 
-TranquilRoute_CutHouse_EventScript_CutMaster_Text_2:
-# 28 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+TranquilRoute_CutHouse_EventScript_CutMaster_Text_3:
+# 34 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	.string "This scroll contains an ancient\n"
 	.string "technique created by the most talented\l"
 	.string "samurai. Pokémon can learn that\l"

--- a/data/maps/TranquilRoute_CutHouse/scripts.pory
+++ b/data/maps/TranquilRoute_CutHouse/scripts.pory
@@ -5,8 +5,14 @@ mapscripts TranquilRoute_CutHouse_MapScripts {
 script TranquilRoute_CutHouse_EventScript_CutMaster {
 	lock
 	faceplayer
-	// TODO EVA Sidequest
-	if (flag(FLAG_RECEIVED_HM_CUT)) {
+	//TODO whatever you wanna do here
+	if(flag(FLAG_COMPLETED_CUT_QUEST)){
+		msgbox(format(
+			"you actually cut all that grass\n"
+			"absolute psycho"
+		))
+	}
+	if(flag(FLAG_RECEIVED_HM_CUT)) {
 		msgbox(format(
 			"Are you finding the Cut technique useful?\p"
 			"No, I still haven't trimmed my garden. I really should get to it…"

--- a/data/scripts/new_game.inc
+++ b/data/scripts/new_game.inc
@@ -287,6 +287,7 @@ EventScript_ResetAllMapFlags::
 	setflag FLAG_SAKU_KURA_RIVALS
 	setflag FLAG_SAKU_KURA_HIDE_ESPEON_MASTERS_HOME
 	setflag FLAG_HIDE_RIVAL_SAKU
+	clearflag FLAG_COMPLETED_CUT_QUEST
 
 	call EventScript_ResetAllBerries
 	end

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -57,7 +57,7 @@
 #define FLAG_HIDE_LOST_MAREEP_3 0x27
 #define FLAG_HIDE_LOST_MAREEP_4 0x28
 #define FLAG_HIDE_LOST_MAREEP_5 0x29
-#define FLAG_UNUSED_0x02A    0x2A // Unused Flag
+#define FLAG_COMPLETED_CUT_QUEST    0x2A
 #define FLAG_UNUSED_0x02B    0x2B // Unused Flag
 #define FLAG_UNUSED_0x02C    0x2C // Unused Flag
 #define FLAG_UNUSED_0x02D    0x2D // Unused Flag


### PR DESCRIPTION
## Description
Added logic at the end of the `FldEff_CutGrass` function that will only run if you are in Tranquil Route to check if you've cut all the grass behind the cut-master's house. If you have, then it will set a new flag called `FLAG_COMPLETED_CUT_QUEST`. When that is set, when you load into Tranquil Route, a map script will flip the metatiles that _were_ the wild grass behind the cut-master's house to become normal grass.

Note/ question: if you leave the map without cutting all of the grass, it will all be back when you return to Tranquil Route. So it's an all-or-nothing type deal. Not sure how you feel about this behavior. If you'd prefer to always keep any section of that grass permanently cut, we'd probably need to switch the implementation to use some EWRAM to keep an array of some sort of all the grass that's been cut. Possible, but non-trivial change, but happy to take a stab if desired :)

Also i put lots of comments in code, feel free to delete/ ask me to delete lol

