### PR TITLE
Party Switching QoL Improvements

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -1427,6 +1427,12 @@ void Task_HandleChooseMonInput(u8 taskId)
         case L_BUTTON:
             DestroyTask(taskId);
             break;
+        case SELECT_BUTTON:
+            gPartyMenu.slotId = *slotPtr;
+            gPartyMenu.slotId2 = 0;
+            gPartyMenu.action = PARTY_ACTION_SWITCH;
+            HandleChooseMonSelection(taskId, slotPtr);
+            break;
         }
     }
 }
@@ -1686,6 +1692,15 @@ static u16 PartyMenuButtonHandler(s8 *slotPtr)
             return L_BUTTON;
         }
         return A_BUTTON; // L is allowed to act as the A Button while CursorCb_Switch is active.
+    }
+
+    if (JOY_NEW(SELECT_BUTTON) && CalculatePlayerPartyCount() >= 2 && gPartyMenu.action == PARTY_ACTION_CHOOSE_MON)
+    {
+        if (gPartyMenu.menuType != PARTY_MENU_TYPE_FIELD)
+            return 0;
+        if (*slotPtr == PARTY_SIZE + 1 || *slotPtr == 0)
+            return 0;
+        return SELECT_BUTTON;
     }
 
     if (movementDir)

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -1424,7 +1424,7 @@ void Task_HandleChooseMonInput(u8 taskId)
                 MoveCursorToConfirm();
             }
             break;
-        case L_BUTTON:
+        case R_BUTTON:
             DestroyTask(taskId);
             break;
         case SELECT_BUTTON:
@@ -1680,7 +1680,7 @@ static u16 PartyMenuButtonHandler(s8 *slotPtr)
     if (JOY_NEW(START_BUTTON))
         return START_BUTTON;
 
-    if (JOY_NEW(L_BUTTON) && CalculatePlayerPartyCount() >= 2 && !IsInvalidPartyMenuActionType(gPartyMenu.action))
+    if (JOY_NEW(R_BUTTON) && CalculatePlayerPartyCount() >= 2 && !IsInvalidPartyMenuActionType(gPartyMenu.action))
     {
         if (gPartyMenu.menuType != PARTY_MENU_TYPE_FIELD)
             return 0;
@@ -1689,9 +1689,9 @@ static u16 PartyMenuButtonHandler(s8 *slotPtr)
         if (gPartyMenu.action != PARTY_ACTION_SWITCH)
         {
             CreateTask(CursorCb_Switch, 1);
-            return L_BUTTON;
+            return R_BUTTON;
         }
-        return A_BUTTON; // L is allowed to act as the A Button while CursorCb_Switch is active.
+        return A_BUTTON; // R is allowed to act as the A Button while CursorCb_Switch is active.
     }
 
     if (JOY_NEW(SELECT_BUTTON) && CalculatePlayerPartyCount() >= 2 && gPartyMenu.action == PARTY_ACTION_CHOOSE_MON)

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -1424,6 +1424,9 @@ void Task_HandleChooseMonInput(u8 taskId)
                 MoveCursorToConfirm();
             }
             break;
+        case L_BUTTON:
+            DestroyTask(taskId);
+            break;
         }
     }
 }
@@ -1618,6 +1621,22 @@ static void Task_HandleCancelChooseMonYesNoInput(u8 taskId)
     }
 }
 
+static bool8 IsInvalidPartyMenuActionType(u8 partyMenuType)
+{
+    return (partyMenuType == PARTY_ACTION_SEND_OUT
+         || partyMenuType == PARTY_ACTION_CANT_SWITCH
+         || partyMenuType == PARTY_ACTION_USE_ITEM
+         || partyMenuType == PARTY_ACTION_ABILITY_PREVENTS
+         || partyMenuType == PARTY_ACTION_GIVE_ITEM
+         || partyMenuType == PARTY_ACTION_GIVE_PC_ITEM
+         || partyMenuType == PARTY_ACTION_GIVE_MAILBOX_MAIL
+         || partyMenuType == PARTY_ACTION_SOFTBOILED
+         || partyMenuType == PARTY_ACTION_CHOOSE_AND_CLOSE
+         || partyMenuType == PARTY_ACTION_MOVE_TUTOR
+         || partyMenuType == PARTY_ACTION_MINIGAME
+         || partyMenuType == PARTY_ACTION_REUSABLE_ITEM);
+}
+
 static u16 PartyMenuButtonHandler(s8 *slotPtr)
 {
     s8 movementDir;
@@ -1654,6 +1673,20 @@ static u16 PartyMenuButtonHandler(s8 *slotPtr)
 
     if (JOY_NEW(START_BUTTON))
         return START_BUTTON;
+
+    if (JOY_NEW(L_BUTTON) && CalculatePlayerPartyCount() >= 2 && !IsInvalidPartyMenuActionType(gPartyMenu.action))
+    {
+        if (gPartyMenu.menuType != PARTY_MENU_TYPE_FIELD)
+            return 0;
+        if (*slotPtr == PARTY_SIZE + 1)
+            return 0;
+        if (gPartyMenu.action != PARTY_ACTION_SWITCH)
+        {
+            CreateTask(CursorCb_Switch, 1);
+            return L_BUTTON;
+        }
+        return A_BUTTON; // L is allowed to act as the A Button while CursorCb_Switch is active.
+    }
 
     if (movementDir)
     {


### PR DESCRIPTION
Press R while hovering over a mon in the party menu to initiate "switching" (pressing R is the same as if you had clicked on the mon and then pressed "switch"), can then press R or A on another mon to swap, or press B to cancel.

Press Select while hovering over a mon in the party menu to switch them to the front of the party.

All based on [QuickSwap Pret Tutorial](https://github.com/pret/pokeemerald/compare/master...LOuroboros:partyScrQuickSwap)