### PR TITLE
Add NPC with Random Mon Cries

### DIFF
--- a/data/maps/TranquilRoute_CutHouse/scripts.inc
+++ b/data/maps/TranquilRoute_CutHouse/scripts.inc
@@ -134,6 +134,83 @@ TranquilRoute_CutHouse_EventScript_CutMaster_5:
 	goto TranquilRoute_CutHouse_EventScript_CutMaster_1
 
 
+TranquilRoute_CutHouse_EventScript_RandomCryGuy::
+# 104 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	lock
+# 105 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	faceplayer
+# 106 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	goto_if_set FLAG_MON_CRY_NPC_GIVE_ITEM, TranquilRoute_CutHouse_EventScript_RandomCryGuy_2
+# 113 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	goto_if_set FLAG_MON_CRY_NPC, TranquilRoute_CutHouse_EventScript_RandomCryGuy_5
+# 120 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	special AssignRandomMonCryVars
+# 121 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_2
+# 122 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	waitse
+# 123 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	playmoncry VAR_0x8008, CRY_MODE_NORMAL
+# 124 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	waitmoncry
+# 125 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_3
+# 127 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	bufferspeciesname STR_VAR_1, VAR_0x8004
+# 128 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	dynmultipush TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_4, VAR_0x8004
+# 130 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	bufferspeciesname STR_VAR_1, VAR_0x8005
+# 131 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	dynmultipush TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_4, VAR_0x8005
+# 133 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	bufferspeciesname STR_VAR_1, VAR_0x8006
+# 134 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	dynmultipush TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_4, VAR_0x8006
+# 136 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	bufferspeciesname STR_VAR_1, VAR_0x8007
+# 137 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	dynmultipush TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_4, VAR_0x8007
+# 139 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, TRUE, 3, DYN_MULTICHOICE_CB_NONE
+# 141 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	compare VAR_RESULT, VAR_0x8008
+	goto_if_eq TranquilRoute_CutHouse_EventScript_RandomCryGuy_8
+# 150 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_7
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_7:
+# 152 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	setflag FLAG_MON_CRY_NPC
+# 153 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	release
+	end
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_2:
+# 108 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_0
+# 109 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	release
+	end
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_5:
+# 115 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_1
+# 116 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	release
+	end
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_8:
+# 143 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_5
+# 144 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	giveitem ITEM_MEWTWONITE_X
+# 145 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	setflag FLAG_MON_CRY_NPC_GIVE_ITEM
+# 146 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	msgbox TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_6
+	goto TranquilRoute_CutHouse_EventScript_RandomCryGuy_7
+
+
 TranquilRoute_CutHouse_EventScript_CutGrassCutscene_Text_0:
 # 35 "data/maps/TranquilRoute_CutHouse/scripts.pory"
 	.string "You actually cut ALL the tall grass?\p"
@@ -182,3 +259,35 @@ TranquilRoute_CutHouse_EventScript_CutMaster_Text_3:
 	.string "Oh, you will need at least one official\n"
 	.string "dojo badge to be able to cut trees\l"
 	.string "and grass, though.$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_0:
+# 108 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "you already got it right\ncome back tomorrow dingus$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_1:
+# 115 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "you guessed wrong\ncome back tomorrow dingus$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_2:
+# 121 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "yo dingus listen to this$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_3:
+# 125 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "now tell me, whomst was it$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_4:
+# 128 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "{STR_VAR_1}$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_5:
+# 143 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "correct dingus, here take this$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_6:
+# 146 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "come back tomorrow$"
+
+TranquilRoute_CutHouse_EventScript_RandomCryGuy_Text_7:
+# 150 "data/maps/TranquilRoute_CutHouse/scripts.pory"
+	.string "wrong dingus, try again tomorrow$"

--- a/data/maps/TranquilRoute_CutHouse/scripts.pory
+++ b/data/maps/TranquilRoute_CutHouse/scripts.pory
@@ -96,3 +96,43 @@ script TranquilRoute_CutHouse_EventScript_CutMaster {
 
 	release
 }
+
+
+
+
+script TranquilRoute_CutHouse_EventScript_RandomCryGuy {
+	lock
+	faceplayer
+	special(AssignRandomMonCryVars)
+	msgbox("yo dingus listen to this")
+	waitse
+	playmoncry(VAR_0x8008, CRY_MODE_NORMAL)
+	waitmoncry
+	msgbox("now tell me, whomst was it")
+
+	bufferspeciesname(STR_VAR_1, VAR_0x8004)
+	dynmultipush("{STR_VAR_1}", VAR_0x8004)
+
+	bufferspeciesname(STR_VAR_1, VAR_0x8005)
+	dynmultipush("{STR_VAR_1}", VAR_0x8005)
+	
+	bufferspeciesname(STR_VAR_1, VAR_0x8006)
+	dynmultipush("{STR_VAR_1}", VAR_0x8006)
+
+	bufferspeciesname(STR_VAR_1, VAR_0x8007)
+	dynmultipush("{STR_VAR_1}", VAR_0x8007)
+
+    // dynmultistack left:req, top:req, ignoreBPress:req, maxBeforeScroll:req, shouldSort:req, initialSelected:req, callbacks:req
+	dynmultistack(0, 0, FALSE, 6, TRUE, 3, DYN_MULTICHOICE_CB_NONE)
+
+    if (var(VAR_RESULT) == VAR_0x8008) 
+	{
+		msgbox("correct dingus")
+	}
+	else
+	{
+		msgbox("wrong dingus")
+	}
+	release
+	end
+}

--- a/data/maps/TranquilRoute_CutHouse/scripts.pory
+++ b/data/maps/TranquilRoute_CutHouse/scripts.pory
@@ -103,6 +103,20 @@ script TranquilRoute_CutHouse_EventScript_CutMaster {
 script TranquilRoute_CutHouse_EventScript_RandomCryGuy {
 	lock
 	faceplayer
+	if(flag(FLAG_MON_CRY_NPC_GIVE_ITEM))
+	{
+		msgbox("you already got it right\ncome back tomorrow dingus")
+		release
+		end
+	}
+
+	if(flag(FLAG_MON_CRY_NPC))
+	{
+		msgbox("you guessed wrong\ncome back tomorrow dingus")
+		release
+		end
+	}
+
 	special(AssignRandomMonCryVars)
 	msgbox("yo dingus listen to this")
 	waitse
@@ -122,17 +136,20 @@ script TranquilRoute_CutHouse_EventScript_RandomCryGuy {
 	bufferspeciesname(STR_VAR_1, VAR_0x8007)
 	dynmultipush("{STR_VAR_1}", VAR_0x8007)
 
-    // dynmultistack left:req, top:req, ignoreBPress:req, maxBeforeScroll:req, shouldSort:req, initialSelected:req, callbacks:req
 	dynmultistack(0, 0, FALSE, 6, TRUE, 3, DYN_MULTICHOICE_CB_NONE)
 
     if (var(VAR_RESULT) == VAR_0x8008) 
 	{
-		msgbox("correct dingus")
+		msgbox("correct dingus, here take this")
+		giveitem(ITEM_MEWTWONITE_X)
+		setflag(FLAG_MON_CRY_NPC_GIVE_ITEM)
+		msgbox("come back tomorrow")
 	}
 	else
 	{
-		msgbox("wrong dingus")
+		msgbox("wrong dingus, try again tomorrow")
 	}
+	setflag(FLAG_MON_CRY_NPC)
 	release
 	end
 }

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -560,3 +560,4 @@ gSpecials::
 	def_special Script_GetChosenMonDefensiveIVs
 	def_special UseBlankMessageToCancelPokemonPic
 	def_special IsMonSeen
+	def_special AssignRandomMonCryVars

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1572,11 +1572,11 @@
 // These flags are cleared once per day
 // The start and end are byte-aligned because the flags are cleared in byte increments
 #define DAILY_FLAGS_START                           (FLAG_UNUSED_0x91F + (8 - FLAG_UNUSED_0x91F % 8))
-#define FLAG_UNUSED_0x920                           (DAILY_FLAGS_START + 0x0)  // Unused Flag
+#define FLAG_MON_CRY_NPC                            (DAILY_FLAGS_START + 0x0)
 #define FLAG_DAILY_CONTEST_LOBBY_RECEIVED_BERRY     (DAILY_FLAGS_START + 0x1)
 #define FLAG_DAILY_SECRET_BASE                      (DAILY_FLAGS_START + 0x2)
 #define FLAG_DAILY_SHUCKLE_BERRY_JUICE (DAILY_FLAGS_START + 0x3)
-#define FLAG_UNUSED_0x924                           (DAILY_FLAGS_START + 0x4)  // Unused Flag
+#define FLAG_MON_CRY_NPC_GIVE_ITEM                  (DAILY_FLAGS_START + 0x4)
 #define FLAG_UNUSED_0x925                           (DAILY_FLAGS_START + 0x5)  // Unused Flag
 #define FLAG_UNUSED_0x926                           (DAILY_FLAGS_START + 0x6)  // Unused Flag
 #define FLAG_UNUSED_0x927                           (DAILY_FLAGS_START + 0x7)  // Unused Flag

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4315,3 +4315,32 @@ void UseBlankMessageToCancelPokemonPic(void)
     AddTextPrinterParameterized(0, FONT_NORMAL, &t, 0, 1, 0, NULL);
     ScriptMenu_HidePokemonPic();
 }
+
+void AssignRandomMonCryVars(void)
+{
+    gSpecialVar_0x8004 = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
+    gSpecialVar_0x8005 = gSpecialVar_0x8004;
+    gSpecialVar_0x8006 = gSpecialVar_0x8004;
+    gSpecialVar_0x8007 = gSpecialVar_0x8004;
+
+    do
+    {
+        gSpecialVar_0x8005 = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
+        
+    } while (gSpecialVar_0x8005 == gSpecialVar_0x8004);
+
+    do
+    {
+        gSpecialVar_0x8006 = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
+        
+    } while (gSpecialVar_0x8006 == gSpecialVar_0x8004 || gSpecialVar_0x8006 == gSpecialVar_0x8005);
+
+    do
+    {
+        gSpecialVar_0x8007 = NationalPokedexNumToSpecies(HoennToNationalOrder((Random() % HOENN_DEX_COUNT) + 1));
+        
+    } while (gSpecialVar_0x8007 == gSpecialVar_0x8004 || gSpecialVar_0x8007 == gSpecialVar_0x8005 || gSpecialVar_0x8007 == gSpecialVar_0x8006);
+
+    u16 answersArray[] = { gSpecialVar_0x8004, gSpecialVar_0x8005, gSpecialVar_0x8006, gSpecialVar_0x8007 };
+    gSpecialVar_0x8008 = answersArray[Random() % 4];
+}


### PR DESCRIPTION
Created  a script for an NPC that imitates a random cry (from the regional dex) everyday - he then lets you pick between 4 random Pokémon names, one of which is the correct answer, and gives you a reward if you guess correctly.

As mentioned, you are only allowed to guess once per day.
Currently has placeholder text / a placeholder reward.


https://github.com/user-attachments/assets/776e5492-d3cd-46a9-aee3-e3a0b12461e4


https://github.com/user-attachments/assets/4f7bff1e-3ecb-41c7-9e94-d63e0ad2f1bd


