### PR TITLE
Replaced Beast Ball with Light Ball + functionality. No graphics.

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -178,6 +178,16 @@
 #define B_SAFARI_BALL_MODIFIER      GEN_LATEST // In Gen8+, Safari Ball's catch multiplier was reduced from x1.5 to x1.
 #define B_SERENE_GRACE_BOOST        GEN_LATEST // In Gen5+, Serene Grace boosts the added flinch chance of King's Rock and Razor Fang.
 
+// Weight thresholds for ITEM_LIGHT_POKE_BALL
+#define B_LIGHT_BALL_MODIFIER_TOO_HEAVY     -20
+#define B_LIGHT_BALL_MODIFIER_AVERAGE       0
+#define B_LIGHT_BALL_MODIFIER_LIGHT         20
+#define B_LIGHT_BALL_MODIFIER_VERY_LIGHT    30
+
+#define B_LIGHT_BALL_WEIGHT_KG_TOO_HEAVY    40
+#define B_LIGHT_BALL_WEIGHT_KG_AVERAGE      5
+#define B_LIGHT_BALL_WEIGHT_KG_LIGHT        2
+
 // Flag settings
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.

--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -436,7 +436,7 @@
 #define OBJ_EVENT_PAL_TAG_BALL_FAST               0x1160
 #define OBJ_EVENT_PAL_TAG_BALL_LEVEL              0x1161
 #define OBJ_EVENT_PAL_TAG_BALL_LURE               0x1162
-#define OBJ_EVENT_PAL_TAG_BALL_HEAVY              0x1163
+#define OBJ_EVENT_PAL_TAG_BALL_HEAVY              0x1163 // SUGGESTION: Consider adding an Object Event for ITEM_LIGHT_POKE_BALL (Light ball)
 #define OBJ_EVENT_PAL_TAG_BALL_LOVE               0x1164
 #define OBJ_EVENT_PAL_TAG_BALL_FRIEND             0x1165
 #define OBJ_EVENT_PAL_TAG_BALL_MOON               0x1166
@@ -444,7 +444,7 @@
 // Gen V
 #define OBJ_EVENT_PAL_TAG_BALL_DREAM              0x1168
 // Gen VII
-#define OBJ_EVENT_PAL_TAG_BALL_BEAST              0x1169
+#define OBJ_EVENT_PAL_TAG_BALL_BEAST              0x1169 // SUGGESTION: Since we don't need this anymore maybe delete or replace it
 // Gen VIII
 #define OBJ_EVENT_PAL_TAG_BALL_STRANGE            0x116A
 #endif //OW_FOLLOWERS_POKEBALLS

--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -29,7 +29,7 @@
 #define ITEM_SAFARI_BALL 23
 #define ITEM_SPORT_BALL 24
 #define ITEM_PARK_BALL 25
-#define ITEM_BEAST_BALL 26
+#define ITEM_LIGHT_POKE_BALL 26 // ITEM_LIGHT_BALL already exists because it's the Pikachu hold item
 #define ITEM_CHERISH_BALL 27
 
 // Note: If moving ball IDs around, updating FIRST_BALL/LAST_BALL is not sufficient

--- a/include/pokeball.h
+++ b/include/pokeball.h
@@ -28,8 +28,9 @@ enum
     BALL_SAFARI,
     BALL_SPORT,
     BALL_PARK,
-    BALL_BEAST,
+    //BALL_BEAST,
     BALL_CHERISH,
+    BALL_LIGHT,
     POKEBALL_COUNT
 };
 

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -183,8 +183,9 @@ static const struct CompressedSpriteSheet sBallParticleSpriteSheets[] =
     [BALL_SAFARI]   = {gBattleAnimSpriteGfx_Particles,      0x100, TAG_PARTICLES_SAFARIBALL},
     [BALL_SPORT]    = {gBattleAnimSpriteGfx_Particles,      0x100, TAG_PARTICLES_SPORTBALL},
     [BALL_PARK]     = {gBattleAnimSpriteGfx_Particles,      0x100, TAG_PARTICLES_PARKBALL},
-    [BALL_BEAST]    = {gBattleAnimSpriteGfx_Particles,      0x100, TAG_PARTICLES_BEASTBALL},
+    //[BALL_BEAST]    = {gBattleAnimSpriteGfx_Particles,      0x100, TAG_PARTICLES_BEASTBALL},
     [BALL_CHERISH]  = {gBattleAnimSpriteGfx_Particles2,     0x100, TAG_PARTICLES_CHERISHBALL},
+    [BALL_LIGHT]    = {gBattleAnimSpriteGfx_Particles2,     0x100, TAG_PARTICLES_HEAVYBALL}, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 static const struct CompressedSpritePalette sBallParticlePalettes[] =
@@ -214,8 +215,9 @@ static const struct CompressedSpritePalette sBallParticlePalettes[] =
     [BALL_SAFARI]   = {gBattleAnimSpritePal_CircleImpact,   TAG_PARTICLES_SAFARIBALL},
     [BALL_SPORT]    = {gBattleAnimSpritePal_CircleImpact,   TAG_PARTICLES_SPORTBALL},
     [BALL_PARK]     = {gBattleAnimSpritePal_CircleImpact,   TAG_PARTICLES_PARKBALL},
-    [BALL_BEAST]    = {gBattleAnimSpritePal_CircleImpact,   TAG_PARTICLES_BEASTBALL},
+    // [BALL_BEAST]    = {gBattleAnimSpritePal_CircleImpact,   TAG_PARTICLES_BEASTBALL},
     [BALL_CHERISH]  = {gBattleAnimSpritePal_Particles2,     TAG_PARTICLES_CHERISHBALL},
+    [BALL_LIGHT]    = {gBattleAnimSpritePal_Particles2,     TAG_PARTICLES_HEAVYBALL}, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 static const union AnimCmd sAnim_RegularBall[] =
@@ -297,8 +299,9 @@ static const u8 sBallParticleAnimNums[POKEBALL_COUNT] =
     [BALL_SAFARI]  = 0,
     [BALL_SPORT]   = 0,
     [BALL_PARK]    = 5,
-    [BALL_BEAST]   = 5,
+    // [BALL_BEAST]   = 5,
     [BALL_CHERISH] = 0,
+    [BALL_LIGHT]   = 0, // (Might not actually be) TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 static const TaskFunc sBallParticleAnimationFuncs[POKEBALL_COUNT] =
@@ -329,8 +332,9 @@ static const TaskFunc sBallParticleAnimationFuncs[POKEBALL_COUNT] =
     [BALL_SAFARI]  = SafariBallOpenParticleAnimation,
     [BALL_SPORT]   = UltraBallOpenParticleAnimation,
     [BALL_PARK]    = UltraBallOpenParticleAnimation,
-    [BALL_BEAST]   = UltraBallOpenParticleAnimation,
+    // [BALL_BEAST]   = UltraBallOpenParticleAnimation,
     [BALL_CHERISH] = MasterBallOpenParticleAnimation,
+    [BALL_LIGHT]   = GreatBallOpenParticleAnimation, // (Might not actually be) TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 static const struct SpriteTemplate sBallParticleSpriteTemplates[POKEBALL_COUNT] =
@@ -560,18 +564,27 @@ static const struct SpriteTemplate sBallParticleSpriteTemplates[POKEBALL_COUNT] 
         .affineAnims = gDummySpriteAffineAnimTable,
         .callback = SpriteCallbackDummy,
     },
-    [BALL_BEAST] = {
-        .tileTag = TAG_PARTICLES_BEASTBALL,
-        .paletteTag = TAG_PARTICLES_BEASTBALL,
+    // [BALL_BEAST] = {
+    //     .tileTag = TAG_PARTICLES_BEASTBALL,
+    //     .paletteTag = TAG_PARTICLES_BEASTBALL,
+    //     .oam = &gOamData_AffineOff_ObjNormal_8x8,
+    //     .anims = sAnims_BallParticles,
+    //     .images = NULL,
+    //     .affineAnims = gDummySpriteAffineAnimTable,
+    //     .callback = SpriteCallbackDummy,
+    // },
+    [BALL_CHERISH] = {
+        .tileTag = TAG_PARTICLES_CHERISHBALL,
+        .paletteTag = TAG_PARTICLES_CHERISHBALL,
         .oam = &gOamData_AffineOff_ObjNormal_8x8,
         .anims = sAnims_BallParticles,
         .images = NULL,
         .affineAnims = gDummySpriteAffineAnimTable,
         .callback = SpriteCallbackDummy,
     },
-    [BALL_CHERISH] = {
-        .tileTag = TAG_PARTICLES_CHERISHBALL,
-        .paletteTag = TAG_PARTICLES_CHERISHBALL,
+    [BALL_LIGHT] = {
+        .tileTag = TAG_PARTICLES_HEAVYBALL, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
+        .paletteTag = TAG_PARTICLES_HEAVYBALL, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
         .oam = &gOamData_AffineOff_ObjNormal_8x8,
         .anims = sAnims_BallParticles,
         .images = NULL,
@@ -608,8 +621,9 @@ const u16 gBallOpenFadeColors[] =
     [BALL_SAFARI] = RGB(23, 30, 20),
     [BALL_SPORT] = RGB(31, 31, 15),
     [BALL_PARK] = RGB(31, 31, 15),
-    [BALL_BEAST] = RGB(31, 31, 15),
+    // [BALL_BEAST] = RGB(31, 31, 15),
     [BALL_CHERISH] = RGB(25, 4, 3),
+    [BALL_LIGHT] = RGB(7, 11, 20), // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 const struct SpriteTemplate gPokeblockSpriteTemplate =
@@ -997,8 +1011,8 @@ u8 ItemIdToBallId(u16 ballItem)
         return BALL_SPORT;
     case ITEM_PARK_BALL:
         return BALL_PARK;
-    case ITEM_BEAST_BALL:
-        return BALL_BEAST;
+    case ITEM_LIGHT_POKE_BALL:
+        return BALL_LIGHT;
     case ITEM_CHERISH_BALL:
         return BALL_CHERISH;
     default:

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15146,10 +15146,11 @@ static void Cmd_handleballthrow(void)
 
         if (gSpeciesInfo[gBattleMons[gBattlerTarget].species].isUltraBeast)
         {
-            if (gLastUsedItem == ITEM_BEAST_BALL)
-                ballMultiplier = 500;
-            else
-                ballMultiplier = 10;
+            // Should never be called anyways because there's no ultra beasts in this rom :masuda~1:
+            // if (gLastUsedItem == ITEM_BEAST_BALL)
+            //     ballMultiplier = 500;
+            // else
+            //     ballMultiplier = 10;
         }
         else
         {
@@ -15301,13 +15302,26 @@ static void Cmd_handleballthrow(void)
                         ballAddition = 40;
                 }
                 break;
+            case ITEM_LIGHT_POKE_BALL:
+                i = GetSpeciesWeight(gBattleMons[gBattlerTarget].species);
+                
+                if (i >= B_LIGHT_BALL_WEIGHT_KG_TOO_HEAVY * 10)
+                    ballAddition = B_LIGHT_BALL_MODIFIER_TOO_HEAVY;
+                else if (i >= B_LIGHT_BALL_WEIGHT_KG_AVERAGE * 10)
+                    ballAddition = B_LIGHT_BALL_MODIFIER_AVERAGE;
+                else if (i >= B_LIGHT_BALL_WEIGHT_KG_LIGHT * 10)
+                    ballAddition = B_LIGHT_BALL_MODIFIER_LIGHT;
+                else
+                    ballAddition = B_LIGHT_BALL_MODIFIER_VERY_LIGHT;
+
+                break;
             case ITEM_DREAM_BALL:
                 if (B_DREAM_BALL_MODIFIER >= GEN_8 && (gBattleMons[gBattlerTarget].status1 & STATUS1_SLEEP || GetBattlerAbility(gBattlerTarget) == ABILITY_COMATOSE))
                     ballMultiplier = 400;
                 break;
-            case ITEM_BEAST_BALL:
-                ballMultiplier = 10;
-                break;
+            // case ITEM_BEAST_BALL:
+            //     ballMultiplier = 10;
+            //     break;
             }
         }
 

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -558,20 +558,20 @@ const struct Item gItemsInfo[] =
         .iconPalette = gItemIconPalette_ParkBall,
     },
 
-    [ITEM_BEAST_BALL] =
-    {
-        .name = _("Beast Ball"),
-        .price = 0,
-        .description = COMPOUND_STRING(
-            "A Ball designed to\n"
-            "catch Ultra Beasts."),
-        .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_USE_BAG_MENU,
-        .battleUsage = EFFECT_ITEM_THROW_BALL,
-        .secondaryId = ITEM_BEAST_BALL - FIRST_BALL,
-        .iconPic = gItemIcon_BeastBall,
-        .iconPalette = gItemIconPalette_BeastBall,
-    },
+    // [ITEM_BEAST_BALL] =
+    // {
+    //     .name = _("Beast Ball"),
+    //     .price = 0,
+    //     .description = COMPOUND_STRING(
+    //         "A Ball designed to\n"
+    //         "catch Ultra Beasts."),
+    //     .pocket = POCKET_POKE_BALLS,
+    //     .type = ITEM_USE_BAG_MENU,
+    //     .battleUsage = EFFECT_ITEM_THROW_BALL,
+    //     .secondaryId = ITEM_BEAST_BALL - FIRST_BALL,
+    //     .iconPic = gItemIcon_BeastBall,
+    //     .iconPalette = gItemIconPalette_BeastBall,
+    // },
 
     [ITEM_CHERISH_BALL] =
     {
@@ -587,6 +587,22 @@ const struct Item gItemsInfo[] =
         .secondaryId = ITEM_CHERISH_BALL - FIRST_BALL,
         .iconPic = gItemIcon_CherishBall,
         .iconPalette = gItemIconPalette_CherishBall,
+    },
+
+    [ITEM_LIGHT_POKE_BALL] =
+    {
+        .name = _("Light Ball"),
+        .price = (I_PRICE >= GEN_7) ? 0 : 300,
+        .description = COMPOUND_STRING(
+            "Works well on\n"
+            "very light\n"
+            "Pokémon."),
+        .pocket = POCKET_POKE_BALLS,
+        .type = ITEM_USE_BAG_MENU,
+        .battleUsage = EFFECT_ITEM_THROW_BALL,
+        .secondaryId = ITEM_LIGHT_POKE_BALL - FIRST_BALL,
+        .iconPic = gItemIcon_HeavyBall, // TODO
+        .iconPalette = gItemIconPalette_HeavyBall, // TODO?
     },
 
 // Medicine

--- a/src/data/object_events/object_event_graphics_info_followers.h
+++ b/src/data/object_events/object_event_graphics_info_followers.h
@@ -48,7 +48,7 @@ const struct ObjectEventGraphicsInfo gPokeballGraphics[POKEBALL_COUNT] = {
     // Gen V
     POKEBALL_GFX_INFO(DREAM),
     // Gen VII
-    POKEBALL_GFX_INFO(BEAST),
+    //POKEBALL_GFX_INFO(BEAST),
     // Gen VIII
     #ifdef ITEM_STRANGE_BALL
     POKEBALL_GFX_INFO(STRANGE),

--- a/src/data/object_events/object_event_pic_tables.h
+++ b/src/data/object_events/object_event_pic_tables.h
@@ -1190,9 +1190,9 @@ static const struct SpriteFrameImage sPicTable_Ball_SPORT[] = {
 static const struct SpriteFrameImage sPicTable_Ball_DREAM[] = {
     POKEBALL_PIC_FRAMES(Dream),
 };
-static const struct SpriteFrameImage sPicTable_Ball_BEAST[] = {
-    POKEBALL_PIC_FRAMES(Beast),
-};
+// static const struct SpriteFrameImage sPicTable_Ball_BEAST[] = {
+//     POKEBALL_PIC_FRAMES(Beast),
+// };
 #ifdef ITEM_STRANGE_BALL
 static const struct SpriteFrameImage sPicTable_Ball_STRANGE[] = {
     POKEBALL_PIC_FRAMES(Strange),

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -566,13 +566,13 @@ static const struct SpritePalette sObjectEventSpritePalettes[] = {
     {gObjectEventPal_FastBall,              OBJ_EVENT_PAL_TAG_BALL_FAST},
     {gObjectEventPal_LevelBall,             OBJ_EVENT_PAL_TAG_BALL_LEVEL},
     {gObjectEventPal_LureBall,              OBJ_EVENT_PAL_TAG_BALL_LURE},
-    {gObjectEventPal_HeavyBall,             OBJ_EVENT_PAL_TAG_BALL_HEAVY},
+    {gObjectEventPal_HeavyBall,             OBJ_EVENT_PAL_TAG_BALL_HEAVY}, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
     {gObjectEventPal_LoveBall,              OBJ_EVENT_PAL_TAG_BALL_LOVE},
     {gObjectEventPal_FriendBall,            OBJ_EVENT_PAL_TAG_BALL_FRIEND},
     {gObjectEventPal_MoonBall,              OBJ_EVENT_PAL_TAG_BALL_MOON},
     {gObjectEventPal_SportBall,             OBJ_EVENT_PAL_TAG_BALL_SPORT},
     {gObjectEventPal_DreamBall,             OBJ_EVENT_PAL_TAG_BALL_DREAM},
-    {gObjectEventPal_BeastBall,             OBJ_EVENT_PAL_TAG_BALL_BEAST},
+    // {gObjectEventPal_BeastBall,             OBJ_EVENT_PAL_TAG_BALL_BEAST},
     // Gen VIII
     #ifdef ITEM_STRANGE_BALL
     {gObjectEventPal_StrangeBall,           OBJ_EVENT_PAL_TAG_BALL_STRANGE},

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -74,6 +74,7 @@ static u16 GetBattlerPokeballItemId(u8 battlerId);
 #define GFX_TAG_PARK_BALL    55024
 #define GFX_TAG_BEAST_BALL   55025
 #define GFX_TAG_CHERISH_BALL 55026
+// TODO: ITEM_LIGHT_POKE_BALL (Light Ball)
 
 const struct CompressedSpriteSheet gBallSpriteSheets[POKEBALL_COUNT] =
 {
@@ -102,8 +103,9 @@ const struct CompressedSpriteSheet gBallSpriteSheets[POKEBALL_COUNT] =
     [BALL_SAFARI]  = {gBallGfx_Safari,  384, GFX_TAG_SAFARI_BALL},
     [BALL_SPORT]   = {gBallGfx_Sport,   384, GFX_TAG_SPORT_BALL},
     [BALL_PARK]    = {gBallGfx_Park,    384, GFX_TAG_PARK_BALL},
-    [BALL_BEAST]   = {gBallGfx_Beast,   384, GFX_TAG_BEAST_BALL},
+    // [BALL_BEAST]   = {gBallGfx_Beast,   384, GFX_TAG_BEAST_BALL},
     [BALL_CHERISH] = {gBallGfx_Cherish, 384, GFX_TAG_CHERISH_BALL},
+    [BALL_LIGHT]   = {gBallGfx_Heavy,   384, GFX_TAG_HEAVY_BALL}, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 const struct CompressedSpritePalette gBallSpritePalettes[POKEBALL_COUNT] =
@@ -133,8 +135,9 @@ const struct CompressedSpritePalette gBallSpritePalettes[POKEBALL_COUNT] =
     [BALL_SAFARI]  = {gBallPal_Safari,  GFX_TAG_SAFARI_BALL},
     [BALL_SPORT]   = {gBallPal_Sport,   GFX_TAG_SPORT_BALL},
     [BALL_PARK]    = {gBallPal_Park,    GFX_TAG_PARK_BALL},
-    [BALL_BEAST]   = {gBallPal_Beast,   GFX_TAG_BEAST_BALL},
+    // [BALL_BEAST]   = {gBallPal_Beast,   GFX_TAG_BEAST_BALL},
     [BALL_CHERISH] = {gBallPal_Cherish, GFX_TAG_CHERISH_BALL},
+    [BALL_LIGHT]   = {gBallPal_Heavy,   GFX_TAG_HEAVY_BALL}, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
 };
 
 static const struct OamData sBallOamData =
@@ -502,20 +505,30 @@ const struct SpriteTemplate gBallSpriteTemplates[POKEBALL_COUNT] =
         .affineAnims = sAffineAnim_BallRotate,
         .callback = SpriteCB_BallThrow,
     },
-    [BALL_BEAST] =
+    // [BALL_BEAST] =
+    // {
+    //     .tileTag = GFX_TAG_BEAST_BALL,
+    //     .paletteTag = GFX_TAG_BEAST_BALL,
+    //     .oam = &sBallOamData,
+    //     .anims = sBallAnimSequences,
+    //     .images = NULL,
+    //     .affineAnims = sAffineAnim_BallRotate,
+    //     .callback = SpriteCB_BallThrow,
+    // },
+    [BALL_CHERISH] =
     {
-        .tileTag = GFX_TAG_BEAST_BALL,
-        .paletteTag = GFX_TAG_BEAST_BALL,
+        .tileTag = GFX_TAG_CHERISH_BALL,
+        .paletteTag = GFX_TAG_CHERISH_BALL,
         .oam = &sBallOamData,
         .anims = sBallAnimSequences,
         .images = NULL,
         .affineAnims = sAffineAnim_BallRotate,
         .callback = SpriteCB_BallThrow,
     },
-    [BALL_CHERISH] =
+    [BALL_LIGHT] =
     {
-        .tileTag = GFX_TAG_CHERISH_BALL,
-        .paletteTag = GFX_TAG_CHERISH_BALL,
+        .tileTag = GFX_TAG_HEAVY_BALL, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
+        .paletteTag = GFX_TAG_HEAVY_BALL, // TODO: ITEM_LIGHT_POKE_BALL (Light ball)
         .oam = &sBallOamData,
         .anims = sBallAnimSequences,
         .images = NULL,


### PR DESCRIPTION
Replaced Beast Ball with the new Light Ball.

Configuration is in include/config/battle.h instead of being hard-coded in the logic like Heavy Ball.

## Description
* `ITEM_BEAST_BALL` and `BALL_BEAST` have been deleted or commented out.
* All references to `ITEM_BEAST_BALL` and `BALL_BEAST` have been deleted or commented out except graphic relevant ones.
* Added `ITEM_LIGHT_POKE_BALL`. It's named like that because there's another item called `ITEM_LIGHT_BALL` relevant to Pikachu.
* Logic of the new ball is located in the `Cmd_handleballthrow` function in `src/battle_script_commands.c` 

## Feature(s) this PR does NOT handle:
* Graphics relevant to the Light Ball and removing Beast Ball graphics.

## **Discord contact info**
@ghoulmage