### PR TITLE
add travelling merchant behaviour

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2368,3 +2368,8 @@
 	.macro hideitemdescription
 	callnative ScriptHideItemDescription
 	.endm
+
+	.macro travellingmerchant
+	callnative ScrCmd_travellingmerchant
+	waitstate
+	.endm

--- a/include/item.h
+++ b/include/item.h
@@ -65,6 +65,7 @@ void SortBerriesOrTMHMs(struct BagPocket *bagPocket);
 void MoveItemSlotInList(struct ItemSlot* itemSlots_, u32 from, u32 to_);
 void ClearBag(void);
 u16 CountTotalItemQuantityInBag(u16 itemId);
+u8 GetNumBadgesObtained(void);
 bool8 AddPyramidBagItem(u16 itemId, u16 count);
 bool8 RemovePyramidBagItem(u16 itemId, u16 count);
 const u8 *ItemId_GetName(u16 itemId);

--- a/include/shop.h
+++ b/include/shop.h
@@ -4,6 +4,7 @@
 extern struct ItemSlot gMartPurchaseHistory[3];
 
 void CreatePokemartMenu(const u16 *);
+void CreateTravellingMerchantMenu(void);
 void CreateDecorationShop1Menu(const u16 *);
 void CreateDecorationShop2Menu(const u16 *);
 void CB2_ExitSellMenu(void);

--- a/src/item.c
+++ b/src/item.c
@@ -28,6 +28,19 @@ static bool32 DoesItemHavePluralName(u16);
 
 EWRAM_DATA struct BagPocket gBagPockets[POCKETS_COUNT] = {0};
 
+static const u32 sBadgesList[NUM_BADGES + 1] =
+{
+    FLAG_BADGE01_GET,
+    FLAG_BADGE02_GET,
+    FLAG_BADGE03_GET,
+    FLAG_BADGE04_GET,
+    FLAG_BADGE05_GET,
+    FLAG_BADGE06_GET,
+    FLAG_BADGE07_GET,
+    FLAG_BADGE08_GET,
+    FLAG_IS_CHAMPION,
+};
+
 #include "data/pokemon/item_effects.h"
 #include "data/items.h"
 
@@ -660,6 +673,16 @@ u16 CountTotalItemQuantityInBag(u16 itemId)
     }
 
     return ownedCount;
+}
+
+u8 GetNumBadgesObtained(void)
+{
+    for (int i = NUM_BADGES - 1; i >= 0; i--) {
+        if (FlagGet(sBadgesList[i])) {
+            return i + 1;  // Returns number of badges obtained / 9 if champion
+        }
+    }
+    return 0;
 }
 
 static bool8 CheckPyramidBagHasItem(u16 itemId, u16 count)

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2103,6 +2103,13 @@ bool8 ScrCmd_pokemart(struct ScriptContext *ctx)
     return TRUE;
 }
 
+bool8 ScrCmd_travellingmerchant(struct ScriptContext *ctx)
+{
+    CreateTravellingMerchantMenu();
+    ScriptContext_Stop();
+    return TRUE;    
+}
+
 bool8 ScrCmd_pokemartdecoration(struct ScriptContext *ctx)
 {
     const void *ptr = (void *)ScriptReadWord(ctx);

--- a/src/shop.c
+++ b/src/shop.c
@@ -37,6 +37,7 @@
 #include "event_data.h"
 #include "constants/decorations.h"
 #include "constants/items.h"
+#include "constants/layouts.h"
 #include "constants/metatile_behaviors.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
@@ -130,6 +131,7 @@ static EWRAM_DATA struct ListMenuItem *sListMenuItems = NULL;
 static EWRAM_DATA u8 (*sItemNames)[ITEM_NAME_LENGTH + 2] = {0};
 static EWRAM_DATA u8 sPurchaseHistoryId = 0;
 EWRAM_DATA struct ItemSlot gMartPurchaseHistory[SMARTSHOPPER_NUM_ITEMS] = {0};
+static EWRAM_DATA u16 sTravellingMerchantInventory[14] = {};
 
 static void Task_ShopMenu(u8 taskId);
 static void Task_HandleShopMenuQuit(u8 taskId);
@@ -172,6 +174,27 @@ static void Task_ReturnToItemListWaitMsg(u8 taskId);
 
 static const u8 sGridPosX[] = { (120 + 16), (160 + 16), (200 + 16) };
 static const u8 sGridPosY[] = { (24 + 16), (64 + 16) };
+
+const u16 travellingMerchantLocation[LAYOUT_HARVEST_SHRINE][5] = {
+    /*gMapHeader.mapLayoutId*/
+    [LAYOUT_SUNRISE_VILLAGE] = { ITEM_POKE_BALL, ITEM_NONE },
+    [LAYOUT_GINKO_WOODS] = { ITEM_GREAT_BALL, ITEM_NONE },
+};
+
+const u16 travellingMerchantProgression[NUM_BADGES + 2][5] = {
+    /*Badges obtained*/
+    [0] = { ITEM_POTION, ITEM_NONE },
+    [1] = { ITEM_SUPER_POTION, ITEM_NONE },
+    [2] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [3] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [4] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [5] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [6] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [7] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [8] = { ITEM_HYPER_POTION, ITEM_NONE },
+    [9] = { ITEM_HYPER_POTION, ITEM_NONE },
+    /*Is champion = 9*/
+};
 
 static const struct YesNoFuncTable sShopPurchaseYesNoFuncs =
 {
@@ -1530,6 +1553,33 @@ void CreatePokemartMenu(const u16 *itemsForSale)
 {
     CreateShopMenu(MART_TYPE_NORMAL);
     SetShopItemsForSale(itemsForSale);
+    ClearItemPurchases();
+    SetShopMenuCallback(ScriptContext_Enable);
+}
+
+void CreateTravellingMerchantMenu(void)
+{
+    u32 currentIndex = 0;
+    memset(sTravellingMerchantInventory, 0, sizeof(sTravellingMerchantInventory));
+    const u16 *locationItems = travellingMerchantLocation[gMapHeader.mapLayoutId];
+    const u16 *progressionItems = travellingMerchantProgression[0];
+
+    // Add location-specific items
+    for (u32 i = 0; locationItems[i] != ITEM_NONE; i++, currentIndex++)
+        sTravellingMerchantInventory[currentIndex] = locationItems[i];
+
+    // Add progression-specific items
+    for (u32 i = 0; progressionItems[i] != ITEM_NONE; i++, currentIndex++)
+        sTravellingMerchantInventory[currentIndex] = progressionItems[i];
+
+    // Add a default if no other items
+    if (currentIndex == 0)
+        sTravellingMerchantInventory[currentIndex++] = ITEM_POTION;
+
+    sTravellingMerchantInventory[currentIndex] = ITEM_NONE;
+
+    CreateShopMenu(MART_TYPE_NORMAL);
+    SetShopItemsForSale(sTravellingMerchantInventory);
     ClearItemPurchases();
     SetShopMenuCallback(ScriptContext_Enable);
 }


### PR DESCRIPTION
Adds a macro for the travelling merchant which builds a shop in C.

Recommended usage:
```
X_EventScript_TravellingMerchant::
	lock
	faceplayer
	message gText_HowMayIServeYou
	waitmessage
	travellingmerchant
	msgbox gText_PleaseComeAgain, MSGBOX_DEFAULT
	release
	end
```
To add items for location/progression, see the following 2D arrays:
```
const u16 travellingMerchantLocation[LAYOUT_HARVEST_SHRINE][5] = {
    /*gMapHeader.mapLayoutId*/
    [LAYOUT_SUNRISE_VILLAGE] = { ITEM_POKE_BALL, ITEM_NONE },
    [LAYOUT_GINKO_WOODS] = { ITEM_GREAT_BALL, ITEM_NONE },
};

const u16 travellingMerchantProgression[NUM_BADGES + 2][5] = {
    /*Badges obtained*/
    [0] = { ITEM_POTION, ITEM_NONE },
    [1] = { ITEM_SUPER_POTION, ITEM_NONE },
    [2] = { ITEM_HYPER_POTION, ITEM_NONE },
    [3] = { ITEM_HYPER_POTION, ITEM_NONE },
    [4] = { ITEM_HYPER_POTION, ITEM_NONE },
    [5] = { ITEM_HYPER_POTION, ITEM_NONE },
    [6] = { ITEM_HYPER_POTION, ITEM_NONE },
    [7] = { ITEM_HYPER_POTION, ITEM_NONE },
    [8] = { ITEM_HYPER_POTION, ITEM_NONE },
    [9] = { ITEM_HYPER_POTION, ITEM_NONE },
    /*Is champion = 9*/
};
```
Adding more should just be a case of following by expample. `ITEM_NONE` is not added to the shop and is only used to mark the end of each list, similar to the overall shop menu list.