### PR TITLE
Fixes for some inconsistencies or unclear behaviour

### DIFF
--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -888,7 +888,7 @@ static u8 ToLowerCaseChar(u8 c)
     return (sToLowerCaseMap[c]) ? sToLowerCaseMap[c] : c;
 }
 
-void ToLowerCase(u8 *input)
+void ToLowerCase(u8 *string)
 {
     while (*input != EOS)
     {

--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -888,22 +888,11 @@ static u8 ToLowerCaseChar(u8 c)
     return (sToLowerCaseMap[c]) ? sToLowerCaseMap[c] : c;
 }
 
-u8 *ToLowerCase(const u8 *input) 
+void ToLowerCase(u8 *input)
 {
-    u8 *buffer = Alloc(StringLength(input) + 1);
-    if (!buffer)
-        return NULL; // Allocation failed
-
-    u8 *start = buffer;  // Save the start of the output buffer
-
-    while (*input != EOS) 
+    while (*input != EOS)
     {
-        *buffer = ToLowerCaseChar(*input);
+        *input = ToLowerCaseChar(*input);  // Modify the input string in place
         input++;
-        buffer++;
     }
-
-    *buffer = EOS;  // Null-terminate the string
-
-    return start;  // Return the start of the buffer
 }

--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -890,9 +890,9 @@ static u8 ToLowerCaseChar(u8 c)
 
 void ToLowerCase(u8 *string)
 {
-    while (*input != EOS)
+    while (*string != EOS)
     {
-        *input = ToLowerCaseChar(*input);  // Modify the input string in place
-        input++;
+        *string = ToLowerCaseChar(*string);  // Modify the string string in place
+        string++;
     }
 }

--- a/gflib/string_util.h
+++ b/gflib/string_util.h
@@ -45,6 +45,6 @@ void ConvertInternationalString(u8 *s, u8 language);
 void StripExtCtrlCodes(u8 *str);
 u8 *StringCopyUppercase(u8 *dest, const u8 *src);
 s32 DoesStringContainMonName(const u8 *string, const u8 *monName);
-u8 *ToLowerCase(const u8 *input);
+void ToLowerCase(u8 *string);
 
 #endif // GUARD_STRING_UTIL_H

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4353,10 +4353,10 @@ void EnterDexRiddleGuess(void)
 
 void GetDexRiddleFeedback(void)
 {
-    u8 *loweredString1 = ToLowerCase(gStringVar1);
-    u8 *loweredString2 = ToLowerCase(gStringVar2);
+    ToLowerCase(gStringVar1);
+    ToLowerCase(gStringVar2);
 
-    if (!StringCompare(loweredString1, loweredString2))
+    if (!StringCompare(gStringVar1, gStringVar2))
     {
         gSpecialVar_Result = 1;
     }
@@ -4364,7 +4364,4 @@ void GetDexRiddleFeedback(void)
     {
         gSpecialVar_Result = 0;
     }
-
-    Free(loweredString1);
-    Free(loweredString1);
 }

--- a/src/shop.c
+++ b/src/shop.c
@@ -175,13 +175,15 @@ static void Task_ReturnToItemListWaitMsg(u8 taskId);
 static const u8 sGridPosX[] = { (120 + 16), (160 + 16), (200 + 16) };
 static const u8 sGridPosY[] = { (24 + 16), (64 + 16) };
 
-const u16 travellingMerchantLocation[LAYOUT_HARVEST_SHRINE][5] = {
+static const u16 sTravellingMerchantLocation[LAYOUT_HARVEST_SHRINE][5] = 
+{
     /*gMapHeader.mapLayoutId*/
     [LAYOUT_SUNRISE_VILLAGE] = { ITEM_POKE_BALL, ITEM_NONE },
     [LAYOUT_GINKO_WOODS] = { ITEM_GREAT_BALL, ITEM_NONE },
 };
 
-const u16 travellingMerchantProgression[NUM_BADGES + 2][5] = {
+static const u16 sTravellingMerchantProgression[NUM_BADGES + 2][5] = 
+{
     /*Badges obtained*/
     [0] = { ITEM_POTION, ITEM_NONE },
     [1] = { ITEM_SUPER_POTION, ITEM_NONE },
@@ -1561,8 +1563,8 @@ void CreateTravellingMerchantMenu(void)
 {
     u32 currentIndex = 0;
     memset(sTravellingMerchantInventory, 0, sizeof(sTravellingMerchantInventory));
-    const u16 *locationItems = travellingMerchantLocation[gMapHeader.mapLayoutId];
-    const u16 *progressionItems = travellingMerchantProgression[GetNumBadgesObtained()];
+    const u16 *locationItems = sTravellingMerchantLocation[gMapHeader.mapLayoutId];
+    const u16 *progressionItems = sTravellingMerchantProgression[GetNumBadgesObtained()];
 
     // Add location-specific items
     for (u32 i = 0; locationItems[i] != ITEM_NONE; i++, currentIndex++)

--- a/src/shop.c
+++ b/src/shop.c
@@ -55,6 +55,8 @@
 
 #define MAX_ITEMS_SHOWN sShopData->gridItems->numItems
 
+#define SHOP_ITEMS(...) { __VA_ARGS__, ITEM_NONE }
+
 enum {
     WIN_BUY_SELL_QUIT,
     WIN_BUY_QUIT,
@@ -178,24 +180,23 @@ static const u8 sGridPosY[] = { (24 + 16), (64 + 16) };
 static const u16 sTravellingMerchantLocation[LAYOUT_HARVEST_SHRINE][5] = 
 {
     /*gMapHeader.mapLayoutId*/
-    [LAYOUT_SUNRISE_VILLAGE] = { ITEM_POKE_BALL, ITEM_NONE },
-    [LAYOUT_GINKO_WOODS] = { ITEM_GREAT_BALL, ITEM_NONE },
+    [LAYOUT_SUNRISE_VILLAGE] = SHOP_ITEMS(ITEM_POKE_BALL),
+    [LAYOUT_GINKO_WOODS] = SHOP_ITEMS(ITEM_GREAT_BALL, ITEM_ULTRA_BALL),
 };
 
 static const u16 sTravellingMerchantProgression[NUM_BADGES + 2][5] = 
 {
     /*Badges obtained*/
-    [0] = { ITEM_POTION, ITEM_NONE },
-    [1] = { ITEM_SUPER_POTION, ITEM_NONE },
-    [2] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [3] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [4] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [5] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [6] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [7] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [8] = { ITEM_HYPER_POTION, ITEM_NONE },
-    [9] = { ITEM_HYPER_POTION, ITEM_NONE },
-    /*Is champion = 9*/
+    [0] = SHOP_ITEMS(ITEM_POTION),
+    [1] = SHOP_ITEMS(ITEM_SUPER_POTION),
+    [2] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [3] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [4] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [5] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [6] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [7] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [8] = SHOP_ITEMS(ITEM_HYPER_POTION),
+    [9] = SHOP_ITEMS(ITEM_HYPER_POTION, ITEM_MAX_POTION), /*Is champion*/
 };
 
 static const struct YesNoFuncTable sShopPurchaseYesNoFuncs =


### PR DESCRIPTION
This PR does the following:

- Removes the parent/child buffer allocation and freeing behaviour from `ToLowerCase` by modifying the string directly. This means that nonmutable strings can no longer be ran through `ToLowerCase` but I doubt this will ever be an issue.

- Made the arrays for the travelling merchant `static` as I don't expect those to ever be used outside of the file, and changed the name to reflect this.

- Added the `SHOP_ITEMS` macro to improve readability of the travelling merchant arrays.