### PR TITLE
fixes tests that read trainer name (leaf)

### DIFF
--- a/test/battle/ai/ai_flag_sequence_switching.c
+++ b/test/battle/ai/ai_flag_sequence_switching.c
@@ -27,14 +27,14 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after a
         }
     } SCENE {
         if (aiSequenceSwitchingFlag) {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Machoke!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Machamp!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Mankey!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Primeape!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Magnezone!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Machoke!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Machamp!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Mankey!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Primeape!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Magnezone!");
         }
         else {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Magnezone!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Magnezone!");
         }
     }
 }

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -35,7 +35,7 @@ AI_SINGLE_BATTLE_TEST("AI switches if Perish Song is about to kill")
             TURN { ; }
             TURN { EXPECT_SWITCH(opponent, 1); }
     } SCENE {
-        MESSAGE("{PKMN} TRAINER LEAF sent out Crobat!");
+        MESSAGE("{PKMN} Trainer LEAF sent out Crobat!");
     }
 }
 
@@ -58,11 +58,11 @@ AI_DOUBLE_BATTLE_TEST("AI will not try to switch for the same pokemon for 2 spot
     } WHEN {
         TURN { EXPECT_SWITCH(opponentLeft, 3); };
     } SCENE {
-        MESSAGE("{PKMN} TRAINER LEAF withdrew Gengar!");
-        MESSAGE("{PKMN} TRAINER LEAF sent out Raticate!");
+        MESSAGE("{PKMN} Trainer LEAF withdrew Gengar!");
+        MESSAGE("{PKMN} Trainer LEAF sent out Raticate!");
         NONE_OF {
-            MESSAGE("{PKMN} TRAINER LEAF withdrew Haunter!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Raticate!");
+            MESSAGE("{PKMN} Trainer LEAF withdrew Haunter!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Raticate!");
         }
     }
 }
@@ -160,9 +160,9 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_MON_CHOICES: AI will not switch in a Pokemo
     } SCENE {
         MESSAGE("Foe Kadabra fainted!");
         if (alakazamFirst) {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Alakazam!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Alakazam!");
         } else {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Blastoise!");
+            MESSAGE("{PKMN} Trainer LEAF sent out Blastoise!");
         }
     }
 }


### PR DESCRIPTION
I know I'm absolutely invaluable to this team with my incredibly dense and feature rich PRs.

I'm bringing you another banger today. Let me present: 1 single VScode find and replace.

Hold your applause, please.