### PR TITLE
Adds catchup exp and a config (true/false)

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -15,6 +15,7 @@
 #define B_TRAINER_EXP_MULTIPLIER    GEN_6 // In Gen7+, trainer battles no longer give a 1.5 multiplier to EXP gain.
 #define B_SPLIT_EXP                 GEN_5 // In Gen6+, all participating mon get full experience.
 #define B_SCALED_EXP                GEN_5 // In Gen5 and Gen7+, experience is weighted by level difference.
+#define B_CATCH_UP_EXP              TRUE // Gives additional experience to mons lower than the level of your highest level mon (based on how far behind they are)
 #define B_UNEVOLVED_EXP_MULTIPLIER  GEN_LATEST // In Gen6+, if the Pokémon is at or past the level where it would be able to evolve, but it has not, it gets a ~1.2 multiplier to EXP gain. Only applies to Pokémon with EVO_LEVEL method.
 #define B_LEVEL_UP_NOTIFICATION     GEN_LATEST // In Gen9+, if the Pokémon gets enough experience to level up multiple times, the message is only displayed once.
 


### PR DESCRIPTION
How it works:
- When EXP is handed out to a Pokemon, the game checks if there is a Pokemon that is a higher level than the one receiving the EXP in the player's party.
- If so, it calculates how many levels of difference there is between those Pokemon.
- EXP is multiplied based on the `sCatchUpExpFactors` table. Where the first result in the table is 0 level difference, the second is 1 level difference, so on so forth:

<img width="522" height="171" alt="catchip" src="https://github.com/user-attachments/assets/d489d761-ec54-46e7-8f59-db9d36978cae" />
