### PR TITLE
Implement pausing Fake RTC in the start menu and outside the overworld

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -38,6 +38,7 @@ struct Main
     /*0x439*/ u8 oamLoadDisabled:1;
     /*0x439*/ u8 inBattle:1;
     /*0x439*/ u8 anyLinkBattlerHasFrontierPass:1;
+    /*0x439*/ u8 isDialogActiveInOverworld:1;
 };
 
 #define GAME_CODE_LENGTH 4

--- a/include/menu.h
+++ b/include/menu.h
@@ -135,5 +135,6 @@ u8 GetSecondaryPopUpWindowId(void);
 void RemoveSecondaryPopUpWindow(void);
 void HBlankCB_DoublePopupWindow(void);
 void RedrawDialogueFrame(void);
+bool32 IsOverworldDialogActive(void);
 
 #endif // GUARD_MENU_H

--- a/src/debug.c
+++ b/src/debug.c
@@ -876,6 +876,7 @@ static void Debug_ShowMenu(DebugFunc HandleInput, const struct DebugMenuOption *
 
     // draw everything
     CopyWindowToVram(windowId, COPYWIN_FULL);
+    gMain.isDialogActiveInOverworld = TRUE;
 }
 
 static void Debug_DestroyMenu(u8 taskId)
@@ -898,6 +899,7 @@ static void Debug_DestroyMenu_Full(u8 taskId)
     DestroyTask(taskId);
     UnfreezeObjectEvents();
     Free(sDebugMenuListData);
+    gMain.isDialogActiveInOverworld = FALSE;
 }
 
 static void Debug_DestroyMenu_Full_Script(u8 taskId, const u8 *script)

--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -12,6 +12,7 @@
 
 extern bool32 InBattle(void);
 
+static bool32 FakeRtc_IsTimeFrozen();
 static void FakeRtc_CalcTimeDifference(struct Time *result, struct SiiRtcInfo *t1, struct Time *t2);
 
 void FakeRtc_Reset(void)
@@ -34,6 +35,15 @@ struct SiiRtcInfo *FakeRtc_GetCurrentTime(void)
 #endif
 }
 
+static bool32 FakeRtc_IsTimeFrozen()
+{
+return  FlagGet(FLAG_PAUSE_FAKERTC)
+     || InBattle()
+     || !InOverworld()
+     || (GetStartMenuWindowId() != WINDOW_NONE)
+     || IsOverworldDialogActive();
+}
+
 void FakeRtc_GetRawInfo(struct SiiRtcInfo *rtc)
 {
     struct SiiRtcInfo *fakeRtc = FakeRtc_GetCurrentTime();
@@ -46,7 +56,7 @@ void FakeRtc_TickTimeForward(void)
     if (!OW_USE_FAKE_RTC)
         return;
 
-    if (FlagGet(FLAG_PAUSE_FAKERTC) || InBattle() || !InOverworld() || GetStartMenuWindowId() != WINDOW_NONE)
+    if (FakeRtc_IsTimeFrozen())
         return;
 
     FakeRtc_AdvanceTimeBy(0, 0, 0, FakeRtc_GetSecondsRatio(), TRUE);

--- a/src/main.c
+++ b/src/main.c
@@ -191,6 +191,8 @@ static void CallCallbacks(void)
 
 void SetMainCallback2(MainCallback callback)
 {
+    if (callback != CB2_Overworld)
+        gMain.isDialogActiveInOverworld = FALSE;
     gMain.callback2 = callback;
     gMain.state = 0;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -350,6 +350,8 @@ void DrawDialogueFrame(u8 windowId, bool8 copyToVram)
     PutWindowTilemap(windowId);
     if (copyToVram == TRUE)
         CopyWindowToVram(windowId, COPYWIN_FULL);
+    if(InOverworld())
+        gMain.isDialogActiveInOverworld = TRUE;
 }
 
 static void WindowFunc_RedrawDialogueFrame(u8 bg, u8 tilemapLeft, u8 tilemapTop, u8 width, u8 height, u8 paletteNum)
@@ -415,6 +417,7 @@ void ClearDialogWindowAndFrame(u8 windowId, bool8 copyToVram)
     ClearWindowTilemap(windowId);
     if (copyToVram == TRUE)
         CopyWindowToVram(windowId, COPYWIN_FULL);
+    gMain.isDialogActiveInOverworld = FALSE;
 }
 
 void ClearStdWindowAndFrame(u8 windowId, bool8 copyToVram)
@@ -756,6 +759,7 @@ void ClearDialogWindowAndFrameToTransparent(u8 windowId, bool8 copyToVram)
     ClearWindowTilemap(windowId);
     if (copyToVram == TRUE)
         CopyWindowToVram(windowId, COPYWIN_FULL);
+    gMain.isDialogActiveInOverworld = FALSE;
 }
 
 static void WindowFunc_ClearDialogWindowAndFrameNullPalette(u8 bg, u8 tilemapLeft, u8 tilemapTop, u8 width, u8 height, u8 paletteNum)
@@ -2268,4 +2272,13 @@ void HBlankCB_DoublePopupWindow(void)
     {
         REG_BG0VOFS = 512 - offset;
     }
+}
+
+bool32 IsOverworldDialogActive(void)
+{
+    if(gMain.isDialogActiveInOverworld && !gMain.inBattle)
+    {
+        return TRUE;
+    }
+    return FALSE;
 }


### PR DESCRIPTION
- Pauses time when not in the overworld (s/o @hashtagmarky)
- Pauses  time when start menu is visible
- Pauses time during dialogue
- Pauses time in the debug menu

<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Additional checks were added to the `FakeRtc_TickTimeForward` function.


## Issue(s) that this PR fixes
Fixes #111 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
kildemal
