### PR TITLE
Follower flash circle

### DIFF
--- a/include/overworld.h
+++ b/include/overworld.h
@@ -64,6 +64,10 @@ extern bool8 gSkipShowMonAnim;
 extern u8 gTimeOfDay;
 extern s16 gTimeUpdateCounter;
 
+extern s8 gFlashX;
+extern s8 gFlashY;
+extern bool8 gDrawFlash;
+
 extern struct TimeBlendSettings gTimeBlend;
 
 extern const struct UCoords32 gDirectionToVectors[];

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -473,7 +473,8 @@ struct SpeciesInfo /*0xC4*/
     u16 enemyShadowSize:3; // This determines the size of the shadow sprite used for an enemy Pokémon's front sprite during battle.
     u16 suppressEnemyShadow:1; // If set to true, then a shadow will not be drawn beneath an enemy Pokémon's front sprite during battle.
     u16 dreamType:2;
-    u16 padding5:10;
+    u16 flashRadius:8;
+    u16 padding5:2;
     // Move Data
     const struct LevelUpMove *levelUpLearnset;
     const u16 *teachableLearnset;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Changes the flash circle in caves to be centered on a following mon if it has a specified `.flashRadius`.
Flash radius is dynamically updated if follower is changed.

## Media

https://github.com/user-attachments/assets/86ba12b2-617c-4b0a-a3eb-60705856450e



## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->
Does not set values for species specific flash circles.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara