### PR TITLE
fix(menu): fix start start menu time suffix

### DIFF
--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -524,17 +524,13 @@ static void ShowTimeWindow(void)
 
     if (rtc->hour < 12)
     {
-        if (rtc->hour == 0)
-            convertedHours = 12;
-        else
-            convertedHours = rtc->hour;
+        convertedHours = rtc->hour;
         suffix = gText_AM;
     }
     else if (rtc->hour == 12)
     {
         convertedHours = 12;
-        if (suffix == gText_AM);
-            suffix = gText_PM;
+        suffix = gText_PM;
     }
     else
     {


### PR DESCRIPTION
Removed a pointless if statement. Time now shows 00:xx from midnight to 1:00 AM and 12:xx from noon to 1:00PM. AM and PM are correctly used.

## Discord contact info
kildemal